### PR TITLE
Update Notification.yaml

### DIFF
--- a/Blueprints/Awtrix/Notification.yaml
+++ b/Blueprints/Awtrix/Notification.yaml
@@ -12,7 +12,7 @@ blueprint:
           filter:
             - integration: mqtt
               manufacturer: Blueforcer
-              model: "AWTRIX Light"
+              model: "AWTRIX 3"
     icon:
       name: Icon number you want to use on device
       default: "1"


### PR DESCRIPTION
The renaming to AWTRIX 3 has surfaced a small but important issue with existing Home Assistant Blueprints. It's essential for any blueprint that references a device model to be updated to reflect the change to AWTRIX